### PR TITLE
Update maxima

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -14,6 +14,7 @@ ENV MaximaPath=/opt/maxima
 
 RUN git clone https://git.code.sf.net/p/maxima/code ${MaximaPath} && \
     cd ${MaximaPath} && \
+    git checkout $maxima_commit && \
     ./bootstrap && \
     ./configure --enable-sbcl --prefix=/usr/local --enable-quiet-build && \
     make install && \

--- a/Dockerfile.alpine-latex
+++ b/Dockerfile.alpine-latex
@@ -17,6 +17,7 @@ ENV MaximaPath=/opt/maxima
 
 RUN git clone https://git.code.sf.net/p/maxima/code ${MaximaPath} && \
     cd ${MaximaPath} && \
+    git checkout $maxima_commit && \
     ./bootstrap && \
     ./configure --enable-sbcl --prefix=/usr/local --enable-quiet-build && \
     make install && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -24,6 +24,7 @@ ENV MaximaPath=/opt/maxima
 RUN mkdir -p ${MaximaPath} && \
     git clone https://git.code.sf.net/p/maxima/code ${MaximaPath} && \
     cd ${MaximaPath} && \
+    git checkout $maxima_commit && \
     ./bootstrap && \
     ./configure --enable-sbcl --prefix=/usr/local --enable-quiet-build && \
     make install && \

--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,16 @@ IFS=$'\n\t'
 DOCKER_REPO_BASE="maxima-docker"
 IMG_TAG=debian-latest
 
-docker build -f Dockerfile.debian -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} .
+MAXIMA_COMMIT=314c889bd4bb5a4448f1c7280fb74aa0dcc57edc
+
+docker build -f Dockerfile.debian -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
 docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}
 
 # Alpine + Maxima
 DOCKER_REPO_BASE="maxima-docker"
 IMG_TAG=alpine-latest
 
-docker build -f Dockerfile.alpine -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} .
+docker build -f Dockerfile.alpine -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
 docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}
 
 # Alpine + Maxima + LaTeX
@@ -24,5 +26,5 @@ curl -X POST -L https://cloud.docker.com/api/build/v1/source/4813e645-4451-4874-
 #DOCKER_REPO_BASE="maxima-docker"
 #IMG_TAG=alpine-latex-latest
 
-#docker build -f Dockerfile.alpine+latex -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} .
+#docker build -f Dockerfile.alpine+latex -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
 #docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}


### PR DESCRIPTION
With the current nightly it is possible to use the argument "--quit-on-error" to quit a batch script on error. This is usefull when testing the tests in a CI and an automated evaluation shall be done
Files: Dockerfile.alpine, Dockerfile.alpine-latex, Dockerfile.debian, and 1 more file